### PR TITLE
Joeyf/fix routing

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,17 +1,18 @@
 ---
 import { useStoryblokApi } from '@storyblok/astro'
 import StoryblokComponent from '@storyblok/astro/StoryblokComponent.astro'
-import BaseLayout from '../layouts/BaseLayout.astro'
+import BaseLayout from '../../layouts/BaseLayout.astro'
  
 export async function getStaticPaths() {
   const storyblokApi = useStoryblokApi()
  
   const { data } = await storyblokApi.get("cdn/stories", {
+    content_type: "blogPost",
     version: import.meta.env.DEV ? "draft" : "published",
-    content_type: 'page',
   });
   
   const stories = Object.values(data.stories);
+
   return stories.map((story) => {
     return {
       params: { slug: story.slug },
@@ -23,12 +24,9 @@ const { slug } = Astro.params
  
 const storyblokApi = useStoryblokApi()
  
-const { data } = await storyblokApi.get(
-  `cdn/stories/${slug}`,
-  {
-    version: 'draft',
-  }
-)
+const { data } = await storyblokApi.get(`cdn/stories/blog/${slug}`, {
+  version: import.meta.env.DEV ? "draft" : "published",
+});
  
 const story = data.story
 ---

--- a/src/pages/blog/_index.astro
+++ b/src/pages/blog/_index.astro
@@ -1,0 +1,16 @@
+---
+import { useStoryblokApi } from "@storyblok/astro";
+import StoryblokComponent from "@storyblok/astro/StoryblokComponent.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const sbApi = useStoryblokApi();
+const { data } = await sbApi.get("cdn/stories/blog", {
+	version: "draft",
+});
+
+const story = data.story;
+---
+
+<BaseLayout>
+	<StoryblokComponent blok={story.content} />
+</BaseLayout>


### PR DESCRIPTION
I followed the Storyblok tutorial in the Astro docs. It seems to have resolved the routing issues.

I believe the main issue was that blog posts were being returned in the Storyblok api response when we really wanted pages.  So you'll see `content_type: 'page'` in the `getStaticPaths()` of the the astro template under /pages.

For the `/pages/blog/` astro template I set `content_type: "blogPost"`